### PR TITLE
Added check for null dataDirectory option

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,10 @@ SteamUser.prototype.setOption = function(option, value) {
 	// Handle anything that needs to happen when particular options update
 	switch(option) {
 		case 'dataDirectory':
-			checkDirExists(value);
+			if(value !== null) {
+				checkDirExists(value);
+			}
+
 			break;
 	}
 };


### PR DESCRIPTION
Checking the directory would break if you tried to use
setOption('dataDirectory', null);

Let me know if there is anything wrong. Tested it and tried to keep nice formatting. Let me know if any problems #kindanew