### PR TITLE
Added myFriendGroups (Friend Tags) functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,13 @@ An object whose keys are 64-bit SteamIDs, and whose values are from the `EFriend
 
 When we leave a group, instead of setting the value to `EFriendRelationship.None`, the key is deleted from the object entirely.
 
+### myFriendGroups
+
+An object containing multiple objects of friend groups.
+- `groupKey` - An object with the key from the group
+	- `name` - A `string` containing the name of the group.
+	- `members` - An array with a list of members consisting of keys that are 64-bit SteamIDs.
+
 # Methods
 
 ### Constructor([client][, options])
@@ -921,10 +928,16 @@ Emitted when our friends list is downloaded from Steam after logon.
 
 Emitted when our group list is downloaded from Steam after logon.
 
+### friendsGroupList
+
+**v1.9.X or later is required to use this event**
+
+Emitted when our friends group list is downloaded from Steam after logon.
+
 ### friendOrChatMessage
-- `senderID` - The message sender, as a `SteamID` object
-- `message` - The message text
 - `room` - The room to which the message was sent. This is the user's `SteamID` if it was a friend message
+- `message` - The message text
+- `senderID` - The message sender, as a `SteamID` object
 
 **v1.9.0 or later is required to use this event**
 

--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ When we leave a group, instead of setting the value to `EFriendRelationship.None
 
 ### myFriendGroups
 
-An object containing multiple objects of friend groups.
-- `groupKey` - An object with the key from the group
+An object containing multiple objects of friend groups (In the client it self the groups are called tags).
+- `groupKey` - An object with the key from the group.
 	- `name` - A `string` containing the name of the group.
 	- `members` - An array with a list of members consisting of keys that are 64-bit SteamIDs.
 
@@ -930,14 +930,14 @@ Emitted when our group list is downloaded from Steam after logon.
 
 ### friendsGroupList
 
-**v1.9.X or later is required to use this event**
+**v1.10.0 or later is required to use this event**
 
-Emitted when our friends group list is downloaded from Steam after logon.
+Emitted when our friends group list is downloaded from Steam after logon (In the client it self the groups are called tags).
 
 ### friendOrChatMessage
-- `room` - The room to which the message was sent. This is the user's `SteamID` if it was a friend message
-- `message` - The message text
 - `senderID` - The message sender, as a `SteamID` object
+- `message` - The message text
+- `room` - The room to which the message was sent. This is the user's `SteamID` if it was a friend message
 
 **v1.9.0 or later is required to use this event**
 

--- a/components/friends.js
+++ b/components/friends.js
@@ -352,7 +352,7 @@ SteamUser.prototype._handlers[Steam.EMsg.ClientFriendsGroupsList] = function (bo
 		var sid = new SteamID(friend.ulSteamID.toString());
 		var sid64 = sid.getSteamID64();
 
-		groupList[friend.nGroupID]['members'].push(parseInt(sid64));
+		groupList[friend.nGroupID]['members'].push(sid64);
 
 		if (body.bincremental) {
 			// For now it doesn't really fire, so can't really check on how to do remove / add stuff with an emit.

--- a/components/friends.js
+++ b/components/friends.js
@@ -337,6 +337,41 @@ SteamUser.prototype._handlers[Steam.EMsg.ClientFriendsList] = function(body) {
 	}
 };
 
+SteamUser.prototype._handlers[Steam.EMsg.ClientFriendsGroupsList] = function (body) {
+	var self = this;
+	var groupList = {};
+
+	body.friendGroups.forEach(function (group) {
+		groupList[group.nGroupID] = {
+			"name": group.strGroupName,
+			"members": []
+		};
+	});
+
+	body.memberships.forEach(function (friend) {
+		var sid = new SteamID(friend.ulSteamID.toString());
+		var sid64 = sid.getSteamID64();
+
+		groupList[friend.nGroupID]['members'].push(parseInt(sid64));
+
+		if (body.bincremental) {
+			// For now it doesn't really fire, so can't really check on how to do remove / add stuff with an emit.
+		}
+	});
+
+	self.myFriendGroups = groupList;
+
+	if (!body.bincremental) {
+		/**
+		 * Emitted when our entire friends group list is loaded.
+		 *
+		 * @event SteamUser#friendsGroupList
+		 */
+
+		this.emit('friendsGroupList');
+	}
+};
+
 function processUser(user) {
 	if(typeof user.gameid === 'object' && user.gameid !== null) {
 		user.gameid = user.gameid.toNumber();

--- a/components/messages.js
+++ b/components/messages.js
@@ -60,6 +60,7 @@ protobufs[Steam.EMsg.ClientFriendMsgIncoming] = Schema.CMsgClientFriendMsgIncomi
 protobufs[Steam.EMsg.ClientFriendMsgEchoToSender] = Schema.CMsgClientFriendMsgIncoming;
 protobufs[Steam.EMsg.ClientFSGetFriendMessageHistory] = Schema.CMsgClientFSGetFriendMessageHistory;
 protobufs[Steam.EMsg.ClientFSGetFriendMessageHistoryResponse] = Schema.CMsgClientFSGetFriendMessageHistoryResponse;
+protobufs[Steam.EMsg.ClientFriendsGroupsList] = Schema.CMsgClientFriendsGroupsList;
 
 // Unified protobufs
 protobufs['GameServers.GetServerList#1_Request'] = Schema.CGameServers_GetServerList_Request;

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ function SteamUser(client, options) {
 	this.chats = {};
 	this.myFriends = {};
 	this.myGroups = {};
+	this.myFriendGroups = {};
 
 	this._sentry = null;
 


### PR DESCRIPTION
friendsGroupList is now emitted when our friends group list is
downloaded from Steam after logon.

user.myFriendGroups