### PR TITLE
Make the client argument optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,11 @@ try {
 }
 
 function SteamUser(client, options) {
+	if(client && client.constructor.name !== 'SteamClient') {
+		options = client;
+		client = null;
+	}
+
 	this.client = client ? client : new Steam.SteamClient();
 	this.steamID = null;
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 var Steam = require('steam');
-var SteamID = require('steamid');
 var AppDirectory = require('appdirectory');
 var FileStorage = require('file-manager');
-var fs = require('fs');
 
 require('util').inherits(SteamUser, require('events').EventEmitter);
 


### PR DESCRIPTION
According to the documentation the [constructor](https://github.com/DoctorMcKay/node-steam-user#constructorclient-options) takes two optional arguments, but calling the constructor like this:
```js
var client = new SteamUser({ dataDirectory: __dirname + '/data' });
```
returns an error.
This patch should fix the issue.