### PR TITLE
Fixes CDN Auth Token Retrieval

### DIFF
--- a/components/cdn.js
+++ b/components/cdn.js
@@ -105,18 +105,19 @@ SteamUser.prototype.getDepotDecryptionKey = function(appID, depotID, callback) {
 
 /**
  * Get an auth token for a particular CDN server.
+ * @param {int} appID
  * @param {int} depotID
  * @param {string} hostname - The hostname of the CDN server for which we want a token
  * @param {function} callback
  */
-SteamUser.prototype.getCDNAuthToken = function(depotID, hostname, callback) {
+SteamUser.prototype.getCDNAuthToken = function(appID, depotID, hostname, callback) {
 	if (this._contentServerTokens[depotID + '_' + hostname] && this._contentServerTokens[depotID + '_' + hostname].expires - Date.now() > (1000 * 60 * 60)) {
 		callback(null, this._contentServerTokens[depotID + '_' + hostname].token, this._contentServerTokens[depotID + '_' + hostname].expires);
 		return;
 	}
 
 	var self = this;
-	this._send(SteamUser.EMsg.ClientGetCDNAuthToken, {"app_id": depotID, "host_name": hostname}, function(body) {
+	this._send(SteamUser.EMsg.ClientGetCDNAuthToken, {"app_id": appID, "depot_id": depotID, "host_name": hostname}, function(body) {
 		if (body.eresult != SteamUser.EResult.OK) {
 			callback(Helpers.eresultError(body.eresult));
 			return;
@@ -189,7 +190,7 @@ SteamUser.prototype.getRawManifest = function(appID, depotID, manifestID, callba
 		var urlBase = "http://" + server.Host;
 		var vhost = server.vhost || server.Host;
 
-		self.getCDNAuthToken(depotID, vhost, function(err, token, expires) {
+		self.getCDNAuthToken(appID, depotID, vhost, function(err, token, expires) {
 			if (err) {
 				callback(err);
 				return;
@@ -246,7 +247,7 @@ SteamUser.prototype.downloadChunk = function(appID, depotID, chunkSha1, contentS
 		var urlBase = "http://" + contentServer.Host;
 		var vhost = contentServer.vhost || contentServer.Host;
 
-		self.getCDNAuthToken(depotID, vhost, function(err, token, expires) {
+		self.getCDNAuthToken(appID, depotID, vhost, function(err, token, expires) {
 			if (err) {
 				callback(err);
 				return;

--- a/doc/CDN.md
+++ b/doc/CDN.md
@@ -36,8 +36,9 @@ callback immediately for subsequent requests for this appID/depotID pair.
 
 Locally cached data expires after 14 days, after which time it will be re-requested.
 
-### getCDNAuthToken(depotID, hostname, callback)
-- `appID` - The ID of the depot for which you want an auth token
+### getCDNAuthToken(appID, depotID, hostname, callback)
+- `appID` - The ID of the app for which you want an auth token
+- `depotID` - The ID of the depot for which you want an auth token
 - `hostname` - The hostname of the content server for which you want an auth token
 - `callback` - Called when the requested data is available
     - `err` - An `Error` object on failure, or `null` on success


### PR DESCRIPTION
The proto `CMsgClientGetCDNAuthToken` requires both the `appID` and `depotID` to get the auth token or else it'll return 401 when used.