### PR TITLE
Prevent crash when SteamID doesn't exist

### DIFF
--- a/components/gameservers.js
+++ b/components/gameservers.js
@@ -36,7 +36,11 @@ SteamUser.prototype.getServerList = function(filter, limit, callback) {
 		"limit": limit
 	}, false, function(body) {
 		callback(body.servers.map(function(server) {
-			server.steamid = new SteamID(server.steamid.toString());
+			try {
+				server.steamid = new SteamID(server.steamid.toString());
+			} catch(e) {
+				
+			}
 			return server;
 		}));
 	});


### PR DESCRIPTION
Prevents error when Steam ID doesn't exist for some servers. Very rarely occurs.