### PR TITLE
Remove broken status flag from persona state request

### DIFF
--- a/components/friends.js
+++ b/components/friends.js
@@ -112,7 +112,7 @@ SteamUser.prototype.unblockUser = function(steamID, callback) {
  */
 SteamUser.prototype.getPersonas = function(steamids, callback) {
 	var Flags = SteamUser.EClientPersonaStateFlag;
-	var flags = Flags.Status | Flags.PlayerName | Flags.QueryPort | Flags.SourceID | Flags.Presence |
+	var flags = Flags.PlayerName | Flags.QueryPort | Flags.SourceID | Flags.Presence |
 		Flags.Metadata | Flags.LastSeen | Flags.ClanInfo | Flags.GameExtraInfo | Flags.GameDataBlob |
 		Flags.ClanTag | Flags.Facebook;
 


### PR DESCRIPTION
Steam's handling of the Status flag in ClientRequestFriendData appears to be broken, as it always returns persona_state: 0 (Offline).

Since Steam echoes ClientPersonaState messages to all clients logged in as the same account, this results in bad status data being sent to all clients. This can be verified by logging into the official Steam client, then logging in through steam-user, which causes all friends to appear to go offline.

Removing the status flag fixes this issue, and does not affect the availability of status data, as Steam automatically sends (correct) statuses for online friends.