### PR TITLE
Fixed downloadChunk is called within named function with wrong scope

### DIFF
--- a/components/cdn.js
+++ b/components/cdn.js
@@ -374,7 +374,7 @@ SteamUser.prototype.downloadFile = function(appID, depotID, fileManifest, output
 					}
 				}
 
-				this.downloadChunk(appID, depotID, chunk.sha, servers[serverIdx], (err, data) => {
+				self.downloadChunk(appID, depotID, chunk.sha, servers[serverIdx], (err, data) => {
 					serversInUse[serverIdx] = false;
 
 					if (killed) {


### PR DESCRIPTION
`dlChunk` function is used within itself and scope for `this` is wrong. `self` is already declared with correct scope outside of function.