### PR TITLE
Load content servers using new web api endpoint

### DIFF
--- a/components/logon.js
+++ b/components/logon.js
@@ -366,6 +366,7 @@ SteamUser.prototype._handlerManager.add(SteamUser.EMsg.ClientLogOnResponse, func
 			this.publicIP = StdLib.IPv4.intToString(body.public_ip);
 			this.cellID = body.cell_id;
 			this.vanityURL = body.vanity_url;
+			this.contentServersReady = true;
 
 			this._connectTime = Date.now();
 			this._connectionCount = 0;
@@ -399,6 +400,7 @@ SteamUser.prototype._handlerManager.add(SteamUser.EMsg.ClientLogOnResponse, func
 			}
 
 			this.emit('loggedOn', body, parental);
+			this.emit('contentServersReady');
 
 			this._getChangelistUpdate();
 
@@ -492,10 +494,14 @@ SteamUser.prototype._handleLogOff = function(result, msg) {
 
 	delete this.publicIP;
 	delete this.cellID;
+	this.contentServersReady = false;
 
 	this._gcTokens = [];
 	this._connectionCount = 0;
 	this._connectTime = 0;
+	this._contentServers = [];
+	this._contentServersTimestamp = 0;
+	this._contentServerTokens = {};
 
 	this._clearChangelistUpdateTimer();
 	clearInterval(this._heartbeatInterval);

--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ function SteamUser(options) {
 	this._authSeqThem = 0;
 	this._hSteamPipe = Math.floor(Math.random() * 1000000) + 1;
 	this._contentServers = [];
+	this._contentServersTimestamp = 0;
 	this._contentServerTokens = {};
 	this._lastNotificationCounts = {};
 	this._sessionID = 0;


### PR DESCRIPTION
ClientServerList message is no longer sent on login

https://steamapi.xpaw.me/#IContentServerDirectoryService

~~Not sure if you want to retain the `contentServersReady` and corresponding event for some kind of backwards compatibility.~~