### PR TITLE
Migrate fs.truncate calls with file descriptor to fs.ftruncate

### DIFF
--- a/components/cdn.js
+++ b/components/cdn.js
@@ -348,7 +348,7 @@ SteamUser.prototype.downloadFile = function(appID, depotID, fileManifest, output
 					}
 
 					outputFd = fd;
-					FS.truncate(outputFd, parseInt(fileManifest.size, 10), (err) => {
+					FS.ftruncate(outputFd, parseInt(fileManifest.size, 10), (err) => {
 						if (err) {
 							FS.closeSync(outputFd);
 							return reject(err);


### PR DESCRIPTION
https://nodejs.org/api/fs.html#fs_fs_truncate_path_len_callback
Passing a file descriptor is deprecated and may result in an error being thrown in the future.