### PR TITLE
Fix the wrong IndexKey

### DIFF
--- a/components/apps.js
+++ b/components/apps.js
@@ -335,7 +335,7 @@ SteamUser.prototype.getProductInfo = function(apps, packages, inclTokens, callba
 							}
 
 							for (let packageid in packageTokens) {
-								tokenPackages.push({appid: parseInt(packageid, 10), access_token: packageTokens[packageid]})
+								tokenPackages.push({packageid: parseInt(packageid, 10), access_token: packageTokens[packageid]})
 							}
 
 							this.getProductInfo(tokenApps, tokenPackages, false, (apps, packages) => {

--- a/components/apps.js
+++ b/components/apps.js
@@ -335,7 +335,7 @@ SteamUser.prototype.getProductInfo = function(apps, packages, inclTokens, callba
 							}
 
 							for (let packageid in packageTokens) {
-								tokenPackages.push({appid: parseInt(packageid, 10), access_token: packageTokens[appid]})
+								tokenPackages.push({appid: parseInt(packageid, 10), access_token: packageTokens[packageid]})
 							}
 
 							this.getProductInfo(tokenApps, tokenPackages, false, (apps, packages) => {


### PR DESCRIPTION
I tried to run the `getProductInfo` function with inclTokens on, but occurred an error that appid is not defined.
So based on the context, I think you wanna put `packageid` here, but for some reasons you put `appid` instead of `packageid`.