### PR TITLE
fix `getGameBadgeLevel` callback

### DIFF
--- a/components/friends.js
+++ b/components/friends.js
@@ -381,6 +381,7 @@ SteamUser.prototype.getGameBadgeLevel = function(appid, callback) {
 			});
 
 			resolve({
+				"steamLevel": body.player_level,
 				"playerLevel": body.player_level,
 				"regularBadgeLevel": regular,
 				"foilBadgeLevel": foil


### PR DESCRIPTION
`getGameBadgeLevel` is supposed to give a `steamLevel` value in the callback/promise (per the docs). In the code, it's called `playerLevel`. This means the value is not accessible in the callback and is under the wrong name in the promise. 

I've fixed it in a way that doesn't break any existing code.