### PR TITLE
Steam returns null pkg.buffer in some accounts

### DIFF
--- a/components/apps.js
+++ b/components/apps.js
@@ -247,7 +247,7 @@ SteamUser.prototype.getProductInfo = function(apps, packages, inclTokens, callba
 					let data = {
 						"changenumber": pkg.change_number,
 						"missingToken": !!pkg.missing_token,
-						"packageinfo": BinaryKVParser.parse(pkg.buffer)[pkg.packageid]
+						"packageinfo": pkg.buffer ? BinaryKVParser.parse(pkg.buffer)[pkg.packageid] : null
 					};
 
 					if ((!cache.packages[pkg.packageid] && requestType == PICSRequestType.Changelist) || (cache.packages[pkg.packageid] && cache.packages[pkg.packageid].changenumber != data.changenumber)) {


### PR DESCRIPTION
When I was testing my bot accounts, there is an UnhandledPromiseRejection emitted, which was caused because the module was trying to parse an empty `pkg.buffer`
For my case, this issue does not happen in all my accounts, but only some. 
I am sure why steam is returning an empty `pkg.buffer`, but test if `pkg.buffer` is null first, could avoid the unhandled promise rejection.

Based on Node 12.18.0, `steam-user` 4.15.5

Here is the Error:
```
UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'toBuffer' of null
    at Object.exports.parse (\node_modules\binarykvparser\index.js:23:13)
    at \node_modules\steam-user\components\apps.js:252:37
    at Array.forEach (<anonymous>)
    at SteamUser.<anonymous> (\node_modules\steam-user\components\apps.js:248:27)
    at SteamUser._handleMessage (\node_modules\steam-user\components\messages.js:543:34)
    at SteamUser._handleNetMessage (\node_modules\steam-user\components\messages.js:480:7)
    at SteamUser.processMulti (\node_modules\steam-user\components\messages.js:572:9)
    at Gunzip.cb (\node_modules\steam-user\components\messages.js:563:17)
    at Gunzip.zlibBufferOnEnd (zlib.js:149:10)
    at Gunzip.emit (events.js:327:22)
```