### PR TITLE
Prevent setTimeout of undefined exception in connection logic

### DIFF
--- a/components/connection.js
+++ b/components/connection.js
@@ -21,6 +21,8 @@ SteamUser.prototype._handleConnectionClose = function() {
 // Handlers
 
 SteamUser.prototype._handlerManager.add(SteamUser.EMsg.ChannelEncryptRequest, function(body) {
+	if (!this._connection || !this._connection.stream) // cannot begin login without a socket, abort
+		return;
 	this._connection.stream.setTimeout(0);
 
 	let protocol = body.readUint32();

--- a/components/connection.js
+++ b/components/connection.js
@@ -21,8 +21,10 @@ SteamUser.prototype._handleConnectionClose = function() {
 // Handlers
 
 SteamUser.prototype._handlerManager.add(SteamUser.EMsg.ChannelEncryptRequest, function(body) {
-	if (!this._connection || !this._connection.stream) // cannot begin login without a socket, abort
+	if (!this._connection || !this._connection.stream) { // cannot begin login without a socket, abort
 		return;
+	}
+	
 	this._connection.stream.setTimeout(0);
 
 	let protocol = body.readUint32();


### PR DESCRIPTION
I'm still trying to trace what span of events lead to the crash occurring, however this little check fix will prevent a program from throwing an exception. This makes the ```ChannelEncryptRequest``` logic only continue if a _connection and stream/socket exists for the login process.

Not a solution to the underlying issue which causes this event of course, but like I said it will stop the exception from occurring.

Solves: https://github.com/DoctorMcKay/node-steam-user/issues/274