### PR TITLE
Request missing tokens for owned packages and include free promotions

### DIFF
--- a/components/apps.js
+++ b/components/apps.js
@@ -572,8 +572,8 @@ SteamUser.prototype.getOwnedApps = function(excludeSharedLicenses) {
 
 		pkg = pkg.packageinfo;
 
-		if (pkg.extended && pkg.extended.expirytime && pkg.extended.expirytime <= Math.floor(Date.now() / 1000)) {
-			return; // This package has expired. Free weekend, usually
+		if (pkg.extended && pkg.extended.expirytime && pkg.extended.expirytime <= Math.floor(Date.now() / 1000) && !pkg.extended.freepromotion) {
+			return; // This package has expired. Free weekend, usually. Free promotions are yours to keep permanently, though.
 		}
 
 		(pkg.appids || []).forEach((appid) => {

--- a/components/apps.js
+++ b/components/apps.js
@@ -535,7 +535,7 @@ SteamUser.prototype._getLicenseInfo = async function() {
 	}
 
 	try {
-		await this.getProductInfo(appids, [], false, undefined, PICSRequestType.PackageContents);
+		await this.getProductInfo(appids, [], true, undefined, PICSRequestType.PackageContents);
 		this.emit('appOwnershipCached');
 	} catch (ex) {
 		this.emit('debug', `Error retrieving app info for licenses: ${ex.message}`);

--- a/components/apps.js
+++ b/components/apps.js
@@ -572,8 +572,8 @@ SteamUser.prototype.getOwnedApps = function(excludeSharedLicenses) {
 
 		pkg = pkg.packageinfo;
 
-		if (pkg.extended && pkg.extended.expirytime && pkg.extended.expirytime <= Math.floor(Date.now() / 1000) && !pkg.extended.freepromotion) {
-			return; // This package has expired. Free weekend, usually. Free promotions are yours to keep permanently, though.
+		if (pkg.extended && pkg.extended.expirytime && !pkg.extended.freepromotion) {
+			return; // Skip: Free weekend, usually. Free promotions are yours to keep permanently, though.
 		}
 
 		(pkg.appids || []).forEach((appid) => {
@@ -629,8 +629,8 @@ SteamUser.prototype.getOwnedDepots = function(excludeSharedLicenses) {
 
 		pkg = pkg.packageinfo;
 
-		if (pkg.extended && pkg.extended.expirytime && pkg.extended.expirytime <= Math.floor(Date.now() / 1000) && !pkg.extended.freepromotion) {
-			return; // This package has expired. Free weekend, usually. Free promotions are yours to keep permanently, though.
+		if (pkg.extended && pkg.extended.expirytime && !pkg.extended.freepromotion) {
+			return; // Skip: Free weekend, usually. Free promotions are yours to keep permanently, though.
 		}
 
 		(pkg.depotids || []).forEach(function(depotid) {

--- a/components/apps.js
+++ b/components/apps.js
@@ -629,8 +629,8 @@ SteamUser.prototype.getOwnedDepots = function(excludeSharedLicenses) {
 
 		pkg = pkg.packageinfo;
 
-		if (pkg.extended && pkg.extended.expirytime && pkg.extended.expirytime <= Math.floor(Date.now() / 1000)) {
-			return; // This package has expired. Free weekend, usually
+		if (pkg.extended && pkg.extended.expirytime && pkg.extended.expirytime <= Math.floor(Date.now() / 1000) && !pkg.extended.freepromotion) {
+			return; // This package has expired. Free weekend, usually. Free promotions are yours to keep permanently, though.
 		}
 
 		(pkg.depotids || []).forEach(function(depotid) {

--- a/components/apps.js
+++ b/components/apps.js
@@ -520,7 +520,7 @@ SteamUser.prototype._getLicenseInfo = async function() {
 	let result;
 
 	try {
-		result = await this.getProductInfo([], packageids, false, undefined, PICSRequestType.Licenses);
+		result = await this.getProductInfo([], packageids, true, undefined, PICSRequestType.Licenses);
 	} catch (ex) {
 		this.emit('debug', `Error retrieving package info for licenses: ${ex.message}`);
 		return;


### PR DESCRIPTION
In theory, this should fix https://github.com/DoctorMcKay/node-steam-user/issues/351
~~I have not tested it yet.~~ ([tested](https://github.com/DoctorMcKay/node-steam-user/pull/352#issuecomment-846228312))

I've also been wondering, in what situation don't you want to request missing tokens? Maybe it should request missing tokens by default (set `inclTokens` by default to `true`), unless explicitly disallowed. What do you think?