### PR TITLE
Bugfix license info

### DIFF
--- a/components/apps.js
+++ b/components/apps.js
@@ -149,8 +149,8 @@ SteamUser.prototype.getProductInfo = function(apps, packages, inclTokens, callba
 		inclTokens = false;
 	}
 
-	// This one actually can take a while, so allow it to go as long as 5 minutes
-	return StdLib.Promises.timeoutCallbackPromise(300000, ['apps', 'packages', 'unknownApps', 'unknownPackages'], callback, (resolve, reject) => {
+	// This one actually can take a while, so allow it to go as long as 10 minutes
+	return StdLib.Promises.timeoutCallbackPromise(600000, ['apps', 'packages', 'unknownApps', 'unknownPackages'], callback, (resolve, reject) => {
 		requestType = requestType || PICSRequestType.User;
 
 		// Steam can send us the full response in multiple responses, so we need to buffer them into one callback

--- a/components/apps.js
+++ b/components/apps.js
@@ -149,8 +149,8 @@ SteamUser.prototype.getProductInfo = function(apps, packages, inclTokens, callba
 		inclTokens = false;
 	}
 
-	// This one actually can take a while, so allow it to go as long as 90 seconds
-	return StdLib.Promises.timeoutCallbackPromise(90000, ['apps', 'packages', 'unknownApps', 'unknownPackages'], callback, (resolve, reject) => {
+	// This one actually can take a while, so allow it to go as long as 5 minutes
+	return StdLib.Promises.timeoutCallbackPromise(300000, ['apps', 'packages', 'unknownApps', 'unknownPackages'], callback, (resolve, reject) => {
 		requestType = requestType || PICSRequestType.User;
 
 		// Steam can send us the full response in multiple responses, so we need to buffer them into one callback

--- a/components/apps.js
+++ b/components/apps.js
@@ -531,7 +531,7 @@ SteamUser.prototype._getLicenseInfo = async function() {
 	let appids = [];
 
 	for (let pkgid in packages) {
-		((packages[pkgid].packageinfo || {}).appids || []).filter(appid => appids.includes(appid)).forEach(appid => appids.push(appid));
+		((packages[pkgid].packageinfo || {}).appids || []).filter(appid => !appids.includes(appid)).forEach(appid => appids.push(appid));
 	}
 
 	try {


### PR DESCRIPTION
Okay, I found something curious. I don't know how it was "working" before, but check this out. 
Before this bugfix, `appids` was always an empty array, because it filter check if appid exists in an empty array, but it should check if appid not exists in this `appids` array.
Turns out it got broken after it was promisified: https://github.com/DoctorMcKay/node-steam-user/blob/50f4b65ec622914465e29c629842e6325c4a0424/components/apps.js#L558

I also included this bugfix in my other PR: https://github.com/DoctorMcKay/node-steam-user/pull/352
But I figured this deserved a separate PR. 