### PR TITLE
Fix requestRichPresence callback/language handling

### DIFF
--- a/components/friends.js
+++ b/components/friends.js
@@ -739,14 +739,14 @@ SteamUser.prototype.uploadRichPresence = function(appid, richPresence) {
  * @return Promise
  */
 SteamUser.prototype.requestRichPresence = function(appid, steamIDs, language, callback) {
+	if (typeof language == 'function') {
+		callback = language;
+		language = null;
+	}
+
 	return StdLib.Promises.timeoutCallbackPromise(10000, null, callback, (resolve, reject) => {
 		if (!Array.isArray(steamIDs)) {
 			steamIDs = [steamIDs];
-		}
-
-		if (typeof language == 'function') {
-			callback = language;
-			language = null;
 		}
 
 		this._send({


### PR DESCRIPTION
Need to figure out which of language/callback is the callback before it gets passed into timeoutCallbackPromise, otherwise the callback won't get called