### PR TITLE
Pics Cache Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,16 @@ Added in 3.3.0.
 
 Defaults to `false`.
 
+### savePicsCache
+
+If `enablePicsCache` is enabled, save product info to disk. (TODO: Improve description)
+
+Added in 4.24.0
+
+Defaults to `false`.
+
+**Warning:** This will significantly increase the storage space that is needed!
+
 ### picsCacheAll
 
 If `picsCacheAll` is enabled, `enablePicsCache` is enabled, and `changelistUpdateInterval` is nonzero, then apps and

--- a/components/apps.js
+++ b/components/apps.js
@@ -156,6 +156,30 @@ class SteamUserApps extends SteamUserAppAuth {
 		});
 	}
 
+	_saveProductInfo({ apps, packages }) {
+		let toSave = [];
+
+		for (let appid in apps) {
+			if (apps[appid].missingToken) {
+				continue;
+			}
+			let filename = `app_info_${appid}.json`;
+			let content = JSON.stringify(apps[appid]);
+			toSave.push({filename, content});
+		}
+
+		for (let packageid in packages) {
+			if (packages[packageid].missingToken) {
+				continue;
+			}
+			let filename = `package_info_${packageid}.json`;
+			let content = JSON.stringify(packages[packageid]);
+			toSave.push({filename, content});
+		}
+		
+		return Promise.all(toSave.map(({filename, content}) => this._saveFile(filename, content)));
+	}
+
 	/**
 	 * Get info about some apps and/or packages from Steam.
 	 * @param {int[]|object[]} apps - Array of AppIDs. May be empty. May also contain objects with keys {appid, access_token}
@@ -313,6 +337,7 @@ class SteamUserApps extends SteamUserAppAuth {
 				// appids and packageids contain the list of IDs that we're still waiting on data for
 				if (appids.length === 0 && packageids.length === 0) {
 					if (!inclTokens) {
+						this._saveProductInfo(response);
 						return resolve(response);
 					}
 
@@ -334,6 +359,7 @@ class SteamUserApps extends SteamUserAppAuth {
 
 					if (tokenlessAppids.length == 0 && tokenlessPackages.length == 0) {
 						// No tokens needed
+						this._saveProductInfo(response);
 						return resolve(response);
 					}
 
@@ -374,6 +400,7 @@ class SteamUserApps extends SteamUserAppAuth {
 							}
 						}
 
+						this._saveProductInfo(response);
 						resolve(response);
 					} catch (ex) {
 						return reject(ex);

--- a/resources/default_options.js
+++ b/resources/default_options.js
@@ -28,6 +28,7 @@ module.exports = {
 	machineIdType: EMachineIDType.AccountNameGenerated,
 	machineIdFormat: ['SteamUser Hash BB3 {account_name}', 'SteamUser Hash FF2 {account_name}', 'SteamUser Hash 3B3 {account_name}'],
 	enablePicsCache: false,
+	savePicsCache: false,
 	picsCacheAll: false,
 	changelistUpdateInterval: 60000,
 	additionalHeaders: {},


### PR DESCRIPTION
- [ ] Allow pics cache to be saved to disk (https://github.com/DoctorMcKay/node-steam-user/issues/188)
- [ ] Read (and sync) saved pics cache to reduce requesting productinfos (https://github.com/DoctorMcKay/node-steam-user/issues/385)
- [ ] Improve efficiency and reduce complexity of `getProductInfo()` (comments [1](https://github.com/DoctorMcKay/node-steam-user/commit/c3f7a7027be4232b5786e1053e41c2edf74f44a7#r68270274) [2](https://github.com/DoctorMcKay/node-steam-user/commit/c3f7a7027be4232b5786e1053e41c2edf74f44a7#r68267882))
- [ ] Request missing tokens by default? ([discussion](https://github.com/DoctorMcKay/node-steam-user/pull/378#issuecomment-1049954125))