### PR TITLE
fix typo jobid_source from job_id_source in sendToGC method

### DIFF
--- a/components/gamecoordinator.js
+++ b/components/gamecoordinator.js
@@ -34,7 +34,7 @@ class SteamUserGameCoordinator extends SteamUserFriends {
 		let header;
 		if (protoBufHeader) {
 			msgType = (msgType | PROTO_MASK) >>> 0;
-			protoBufHeader.job_id_source = sourceJobId;
+			protoBufHeader.jobid_source = sourceJobId;
 			let protoHeader = SteamUserGameCoordinator._encodeProto(Schema.CMsgProtoBufHeader, protoBufHeader);
 			header = Buffer.alloc(8);
 			header.writeUInt32LE(msgType, 0);


### PR DESCRIPTION
https://github.com/DoctorMcKay/node-steam-user/blob/master/protobufs/common.proto#L475

After fixing the naming, `sourceJobId` is correctly written to `protoHeader`. Otherwise `protoHeader` is empty.