### PR TITLE
propagate errors upwards correctly

### DIFF
--- a/components/appauth.js
+++ b/components/appauth.js
@@ -118,9 +118,13 @@ class SteamUserAppAuth extends SteamUserAccount {
 
 					buffer = buffer.flip().toBuffer();
 
-					// We need to activate our ticket
-					await this.activateAuthSessionTickets(appid, buffer);
-					resolve({sessionTicket: buffer});
+					try {
+						// We need to activate our ticket
+						await this.activateAuthSessionTickets(appid, buffer);
+						resolve({sessionTicket: buffer});
+					} catch (err) {
+						reject(err);
+					}
 				};
 
 				// Do we have any GC tokens?


### PR DESCRIPTION
buildToken is called asynchronously, so we have to try catch the await call inside it and use the reject function to propagate errors up in the call stack

closes #428 (and #425)