### PR TITLE
emit error 'Already logged on, cannot log on again' instead of throwing

### DIFF
--- a/components/09-logon.js
+++ b/components/09-logon.js
@@ -25,7 +25,8 @@ class SteamUserLogon extends SteamUserSentry {
 		// they appear to be already logged on (the steamID property is set to null only *after* the error event is emitted)
 		process.nextTick(async () => {
 			if (this.steamID) {
-				throw new Error('Already logged on, cannot log on again');
+				this.emit('error', new Error('Already logged on, cannot log on again'));
+				return;
 			}
 
 			this.steamID = null;


### PR DESCRIPTION
If we throw error here, it will cause unhandled promise rejection, we can't manually catch this exception.

https://github.com/DoctorMcKay/node-steam-user/blob/3264c4530abaa1242027e1909f1f328178522d5a/components/09-logon.js#L26-L29

This can happen when a process is blocked by a synchronous operation. Based on the logic of _enqueueLogonAttempt.

https://github.com/DoctorMcKay/node-steam-user/blob/3264c4530abaa1242027e1909f1f328178522d5a/components/09-logon.js#L430-L441