### PR TITLE
Fix load built-in CMList

### DIFF
--- a/components/09-logon.js
+++ b/components/09-logon.js
@@ -223,8 +223,11 @@ class SteamUserLogon extends SteamUserSentry {
 				try {
 					this._cmList = await new Promise((resolve, reject) => {
 						Fs.readFile(Path.join(__dirname, '../resources/servers.json'), (err, data) => {
-							if (err) reject(err);
-							resolve(JSON.parse(data.toString('utf8')));
+							if (err) {
+								reject(err);
+							} else {
+								resolve(JSON.parse(data.toString('utf8')));
+							}
 						});
 					});
 				} catch (ex) {

--- a/components/09-logon.js
+++ b/components/09-logon.js
@@ -1,7 +1,5 @@
 const ByteBuffer = require('bytebuffer');
 const Crypto = require('crypto');
-const FS = require('fs');
-const Path = require('path');
 const StdLib = require('@doctormckay/stdlib');
 const SteamID = require('steamid');
 
@@ -221,17 +219,6 @@ class SteamUserLogon extends SteamUserSentry {
 
 			if (!this._cmList) {
 				// Get built-in list as a last resort
-				let builtInCmListExists = await new Promise((resolve) => {
-					FS.stat(Path.join(__dirname, '../resources/servers.json'), (err) => {
-						resolve(!err);
-					});
-				});
-
-				if (!builtInCmListExists) {
-					this.emit('error', 'CMlist is missing and could not be retrieved from WebAPI');
-					return;
-				}
-
 				this._cmList = require('../resources/servers.json');
 			}
 

--- a/components/09-logon.js
+++ b/components/09-logon.js
@@ -27,8 +27,7 @@ class SteamUserLogon extends SteamUserSentry {
 		// they appear to be already logged on (the steamID property is set to null only *after* the error event is emitted)
 		process.nextTick(async () => {
 			if (this.steamID) {
-				this.emit('error', new Error('Already logged on, cannot log on again'));
-				return;
+				throw new Error('Already logged on, cannot log on again');
 			}
 
 			this.steamID = null;

--- a/components/09-logon.js
+++ b/components/09-logon.js
@@ -25,7 +25,8 @@ class SteamUserLogon extends SteamUserSentry {
 		// they appear to be already logged on (the steamID property is set to null only *after* the error event is emitted)
 		process.nextTick(async () => {
 			if (this.steamID) {
-				throw new Error('Already logged on, cannot log on again');
+				this.emit('error', new Error('Already logged on, cannot log on again'));
+				return;
 			}
 
 			this.steamID = null;

--- a/components/09-logon.js
+++ b/components/09-logon.js
@@ -1,5 +1,7 @@
 const ByteBuffer = require('bytebuffer');
 const Crypto = require('crypto');
+const FS = require('fs');
+const Path = require('path');
 const StdLib = require('@doctormckay/stdlib');
 const SteamID = require('steamid');
 
@@ -219,6 +221,17 @@ class SteamUserLogon extends SteamUserSentry {
 
 			if (!this._cmList) {
 				// Get built-in list as a last resort
+				let builtInCmListExists = await new Promise((resolve) => {
+					FS.stat(Path.join(__dirname, '../resources/servers.json'), (err) => {
+						resolve(!err);
+					});
+				});
+
+				if (!builtInCmListExists) {
+					this.emit('error', 'CMlist is missing and could not be retrieved from WebAPI');
+					return;
+				}
+
 				this._cmList = require('../resources/servers.json');
 			}
 


### PR DESCRIPTION
In ideal world we don't need this, because we must have CMList at least one place (storage cache, webapi, built-in).
But, in cases when steam is lagging and we don't have CMList at storage - we can get unhandled promise rejection or another error if we use bundlers like [pkg](https://github.com/vercel/pkg/).

And.. seems like we don't have built-in CMList at all (by path ../resources/servers.json)