### PR TITLE
Fix endAuthSessions with provided SteamIDs

### DIFF
--- a/components/appauth.js
+++ b/components/appauth.js
@@ -302,7 +302,7 @@ class SteamUserAppAuth extends SteamUserAccount {
 			let matchingTickets = this._activeAuthTickets.filter(tkt => tkt.gameid == appid && tkt.steamid != 0);
 			if (steamIDs) {
 				steamIDs = steamIDs.map(Helpers.steamID).map(sid => sid.getSteamID64());
-				matchingTickets = matchingTickets.filter(tkt => steamIDs.includes(tkt.steamid.toString()));
+				matchingTickets = matchingTickets.filter(tkt => steamIDs.includes(tkt.steamid));
 			}
 
 			this.emit('debug', `Got ${matchingTickets.length} matching tickets to end auth sessions for`);

--- a/components/appauth.js
+++ b/components/appauth.js
@@ -302,7 +302,7 @@ class SteamUserAppAuth extends SteamUserAccount {
 			let matchingTickets = this._activeAuthTickets.filter(tkt => tkt.gameid == appid && tkt.steamid != 0);
 			if (steamIDs) {
 				steamIDs = steamIDs.map(Helpers.steamID).map(sid => sid.getSteamID64());
-				matchingTickets = matchingTickets.filter(tkt => steamIDs.includes(tkt.steamid.getSteamID64()));
+				matchingTickets = matchingTickets.filter(tkt => steamIDs.includes(tkt.steamid.toString()));
 			}
 
 			this.emit('debug', `Got ${matchingTickets.length} matching tickets to end auth sessions for`);


### PR DESCRIPTION
tkt.steamid actually is string or number here
https://github.com/DoctorMcKay/node-steam-user/blob/3264c4530abaa1242027e1909f1f328178522d5a/components/appauth.js#L305

not SteamID instance, based on code here
https://github.com/DoctorMcKay/node-steam-user/blob/3264c4530abaa1242027e1909f1f328178522d5a/components/appauth.js#L202-L230

so, if we call .getSteamID64() on string or number - we got error