### PR TITLE
Add clearPicsCache function to reduce memory usage and store job types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1059,6 +1059,15 @@ If `filter` is a boolean, it is interpreted as `excludeShared` for backward comp
 `ownsPackage(16018, true)` is the same as `ownsPackage(16018, {excludeShared: true})`.
 This usage is deprecated and will be removed in a future release.
 
+### clearPicsCache()
+
+**v4.xx.x or later is required to use this method**  
+
+Clears the content of the `picsCache` object and removes any associated jobs to free memory.  
+Make sure to disable [`changelistUpdateInterval`](#changelistUpdateInterval) if the cache should not get repopulated.  
+
+`enablePicsCache` must be `true` to use this method. Otherwise, an `Error` will be thrown.  
+
 ### getStoreTagNames(language, tagIDs, callback)
 - `language` - The language you want tag names in, e.g. "english" or "spanish"
 - `tagIDs` - An array of one or more tag IDs

--- a/components/03-messages.js
+++ b/components/03-messages.js
@@ -438,6 +438,7 @@ class SteamUserMessages extends SteamUserConnection {
 		if (callback) {
 			jobIdSource = ++this._currentJobID;
 			this._jobs[jobIdSource] = callback;
+			this._jobs[jobIdSource].type = emsg; // Save type of this job to be able to filter the object later on
 
 			// Clean up old job callbacks after 2 minutes
 			this._jobCleanupTimers.push(setTimeout(() => delete this._jobs[jobIdSource], 1000 * 60 * 2));

--- a/components/apps.js
+++ b/components/apps.js
@@ -582,6 +582,17 @@ class SteamUserApps extends SteamUserAppAuth {
 			apps: {},
 			packages: {}
 		};
+
+		// Filter jobs object for left over references to the old picsCache content so it will be garbage collected instantly
+		Object.keys(this._jobs).forEach((e) => {
+			let k = this._jobs[e];
+
+			if (k.type && [ EMsg.ClientPICSChangesSinceRequest, EMsg.ClientPICSProductInfoRequest, EMsg.ClientPICSAccessTokenRequest ].includes(k.type)) {
+				delete this._jobs[e];
+				clearTimeout(this._jobCleanupTimers[e]);
+				delete this._jobCleanupTimers[e];
+			}
+		});
 	}
 
 	/**

--- a/components/apps.js
+++ b/components/apps.js
@@ -568,6 +568,23 @@ class SteamUserApps extends SteamUserAppAuth {
 	}
 
 	/**
+	 * Clears the current picsCache content.
+	 * Make sure to disable 'changelistUpdateInterval' if the cache should not get repopulated.
+	 */
+	clearPicsCache() {
+		if (!this.options.enablePicsCache) {
+			throw new Error("PICS cache is not enabled.");
+		}
+
+		// Reset cache back to default
+		this.picsCache = {
+			changenumber: 0,
+			apps: {},
+			packages: {}
+		};
+	}
+
+	/**
 	 * @protected
 	 */
 	async _getLicenseInfo() {


### PR DESCRIPTION
This PR adds a clearPicsCache() function to reduce memory usage if content is not needed anymore.  

In order for the garbage collector to instantly free the memory being used we need to filter the `jobs` object.  
I added a `type` property to every `jobs` entry which stores the `EMsg` value of the associated request. This allows us to only filter PICS related entries instead of needing to nuke the whole object.

Related forum thread:
https://dev.doctormckay.com/topic/4476-advice-needed-on-clearing-picscache-im-struggling-with-ram-usage/