### PR TITLE
v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,9 +593,9 @@ There are five ways to log onto Steam:
 #### Using Refresh Tokens
 
 The Steam client uses refresh tokens when logging on. You can obtain a refresh token using the
-[steam-session module](https://www.npmjs.com/package/steam-session), or you can log on to steam-user using your account
-name and password as normal, and steam-user will internally fetch a refresh token if it can
-(see [legacy authentication](#legacy-authentication)).
+[steam-session module](https://www.npmjs.com/package/steam-session), or you can log on to steam-user using your account name and password as normal. When
+logging on using your account name and password, steam-user will internally fetch a refresh token, emit the
+[`refreshToken`](#refreshtoken) event, and then use that token to log on to Steam.
 
 As of 2022-09-03, refresh tokens are JWTs that are valid for ~200 days. You can keep using the same refresh token to log
 on until it expires. You can find out when a token expires by [decoding it](https://www.npmjs.com/search?q=jwt) and checking
@@ -622,7 +622,7 @@ Logs you off of Steam and closes the connection.
 Logs you off of Steam and then immediately back on. This can only be used if one of the following criteria are met:
 
 - You're logged into an anonymous account
-- You're logged into an individual account, you logged in using an account name and password, and you didn't use [legacy authentication](#legacy-authentication)
+- You're logged into an individual account and you logged in using an account name and password
 - You're logged into an individual account and you used a `refreshToken` to log on
 
 Attempts to call this method under any other circumstance will result in an `Error` being thrown and nothing else will happen.
@@ -1887,6 +1887,8 @@ This may be emitted before [`loggedOn`](#loggedon) fires.
 
 ### refreshToken
 - `refreshToken` - A string containing your new refresh token
+
+**v5.0.0 or later is required to use this event**
 
 Emitted when a new refresh token is issued. This will always be emitted when logging on using an account name and password,
 and when logging on using an existing refresh token, this may be issued if a new refresh token is issued because your

--- a/README.md
+++ b/README.md
@@ -1879,6 +1879,8 @@ directly, without Steam sending a LoggedOff message.
 ### machineAuthToken
 - `machineAuthToken` - A string containing your new machine auth token
 
+**v4.29.0 or later is required to use this event**
+
 Emitted when a new machine auth token is issued. This is only relevant for accounts using email Steam Guard. Even if you
 are using email Steam Guard, you likely don't need to worry about this event as steam-user will [automatically manage
 your machine auth tokens for you](#machine-auth-tokens).

--- a/README.md
+++ b/README.md
@@ -1802,7 +1802,8 @@ data which only the developer/publisher of the game can do anything with.
 
 ## ID Events
 
-Events marked as **ID events** are special. They all have a `SteamID` object as their first parameter. In addition to the event itself firing, a second event comprised of `eventName + "#" + steamID.getSteamID64()` is fired.
+Events marked as **ID events** are special. They all have a `SteamID` object as their first parameter. In addition to the
+event itself firing, a second event comprised of `eventName + "#" + steamID.getSteamID64()` is fired.
 
 For example:
 
@@ -1881,6 +1882,15 @@ directly, without Steam sending a LoggedOff message.
 Emitted when a new machine auth token is issued. This is only relevant for accounts using email Steam Guard. Even if you
 are using email Steam Guard, you likely don't need to worry about this event as steam-user will [automatically manage
 your machine auth tokens for you](#machine-auth-tokens).
+
+This may be emitted before [`loggedOn`](#loggedon) fires.
+
+### refreshToken
+- `refreshToken` - A string containing your new refresh token
+
+Emitted when a new refresh token is issued. This will always be emitted when logging on using an account name and password,
+and when logging on using an existing refresh token, this may be issued if a new refresh token is issued because your
+provided token is nearly expired.
 
 This may be emitted before [`loggedOn`](#loggedon) fires.
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,16 @@ Added in 3.5.0.
 
 Defaults to `true`.
 
+### renewRefreshTokens
+
+If true, then `SteamUser` will attempt to renew your refresh token every time you call [`logOn()`](#logondetails) by
+passing a refresh token. If renewal succeeds, the [`refreshToken`](#refreshtoken) event will be emitted, and the refresh
+token you used to log on will become invalid.
+
+Added in 5.0.0.
+
+Defaults to `false`.
+
 # Properties [^](#contents)
 
 ### steamID
@@ -1893,8 +1903,8 @@ This may be emitted before [`loggedOn`](#loggedon) fires.
 **v5.0.0 or later is required to use this event**
 
 Emitted when a new refresh token is issued. This will always be emitted when logging on using an account name and password,
-and when logging on using an existing refresh token, this may be issued if a new refresh token is issued because your
-provided token is nearly expired.
+and when logging on using an existing refresh token, this may be emitted if a new refresh token is issued because your
+provided token is nearly expired (only if [`renewRefreshTokens`](#renewrefreshtokens) is set to true).
 
 This may be emitted before [`loggedOn`](#loggedon) fires.
 

--- a/README.md
+++ b/README.md
@@ -1904,7 +1904,8 @@ Emitted when a steamcommunity.com web session is successfully negotiated.
 This will automatically be emitted on logon (**unless** you used a `webLogonToken` to log on) and in response to
 [`webLogOn`](#weblogon) calls.
 
-Some libraries require you to provide your `sessionID`, others don't. If your library doesn't, you can safely ignore it.
+Some libraries require you to provide your `sessionID`, others don't. If the library you're using doesn't need you to
+provide a `sessionID`, then you can safely ignore it.
 
 [Read more about how cookies work and interact with other modules.](https://dev.doctormckay.com/topic/365-cookies/#user-cookieusage)
 

--- a/components/03-messages.js
+++ b/components/03-messages.js
@@ -9,6 +9,10 @@ const Schema = require('../protobufs/generated/_load.js');
 const EMsg = require('../enums/EMsg.js');
 const EResult = require('../enums/EResult.js');
 
+// steam-session dependencies
+const {LoginSession, EAuthTokenPlatformType} = require('steam-session');
+const CMAuthTransport = require('./classes/CMAuthTransport');
+
 const JOBID_NONE = '18446744073709551615';
 const PROTO_MASK = 0x80000000;
 
@@ -729,6 +733,16 @@ class SteamUserMessages extends SteamUserConnection {
 		};
 
 		this._send(header, SteamUserMessages._encodeProto(Proto, methodData), callback);
+	}
+
+	_getLoginSession() {
+		if (!this._loginSession) {
+			this._loginSession = new LoginSession(EAuthTokenPlatformType.SteamClient, {
+				transport: new CMAuthTransport(this)
+			});
+		}
+
+		return this._loginSession;
 	}
 }
 

--- a/components/07-web.js
+++ b/components/07-web.js
@@ -2,10 +2,6 @@ const Crypto = require('crypto');
 const SteamCrypto = require('@doctormckay/steam-crypto');
 const SteamID = require('steamid');
 
-// steam-session dependencies
-const {LoginSession, EAuthTokenPlatformType} = require('steam-session');
-const CMAuthTransport = require('./classes/CMAuthTransport.js');
-
 const EMsg = require('../enums/EMsg.js');
 const EResult = require('../enums/EResult.js');
 
@@ -38,8 +34,7 @@ class SteamUserWeb extends SteamUserWebAPI {
 		// The client uses access tokens for its session cookie now. Even though we might already technically have an
 		// access token available from your initial auth, the client always requests a new one, so let's mimic that behavior.
 
-		let transport = new CMAuthTransport(this);
-		let session = new LoginSession(EAuthTokenPlatformType.SteamClient, {transport});
+		let session = this._getLoginSession();
 		session.refreshToken = this._logOnDetails.access_token;
 		session.getWebCookies().then((cookies) => {
 			if (!cookies.some(c => c.startsWith('sessionid='))) {

--- a/components/07-web.js
+++ b/components/07-web.js
@@ -2,6 +2,10 @@ const Crypto = require('crypto');
 const SteamCrypto = require('@doctormckay/steam-crypto');
 const SteamID = require('steamid');
 
+// steam-session dependencies
+const {LoginSession, EAuthTokenPlatformType} = require('steam-session');
+const CMAuthTransport = require('./classes/CMAuthTransport.js');
+
 const EMsg = require('../enums/EMsg.js');
 const EResult = require('../enums/EResult.js');
 
@@ -25,7 +29,7 @@ class SteamUserWeb extends SteamUserWebAPI {
 			throw new Error('Must not be anonymous user to use webLogOn (check to see you passed in valid credentials to logOn)')
 		}
 
-		if (!Helpers.newAuthCapable() || !this._logOnDetails.access_token) {
+		if (!this._logOnDetails.access_token) {
 			// deprecated
 			this._send(EMsg.ClientRequestWebAPIAuthenticateUserNonce, {});
 			return;
@@ -33,9 +37,6 @@ class SteamUserWeb extends SteamUserWebAPI {
 
 		// The client uses access tokens for its session cookie now. Even though we might already technically have an
 		// access token available from your initial auth, the client always requests a new one, so let's mimic that behavior.
-
-		const {LoginSession, EAuthTokenPlatformType} = require('steam-session');
-		const CMAuthTransport = require('./classes/CMAuthTransport.js');
 
 		let transport = new CMAuthTransport(this);
 		let session = new LoginSession(EAuthTokenPlatformType.SteamClient, {transport});

--- a/components/08-machineauth.js
+++ b/components/08-machineauth.js
@@ -6,15 +6,6 @@ const SteamUserBase = require('./00-base.js');
 const SteamUserWeb = require('./07-web.js');
 
 class SteamUserMachineAuth extends SteamUserWeb {
-	/**
-	 * @param {Buffer|string} sentry
-	 * @deprecated Use `machineAuthToken` property in `logOn()` instead
-	 */
-	setSentry(sentry) {
-		this._machineAuthTokenSetByDeprecatedSetSentry = true;
-		this._machineAuthToken = Buffer.isBuffer(sentry) ? sentry.toString('utf8') : sentry;
-	}
-
 	_getMachineAuthFilename() {
 		let accountName = (this._logOnDetails.account_name || this._logOnDetails._newAuthAccountName).toLowerCase();
 		return `machineAuthToken.${accountName}.txt`;
@@ -24,7 +15,6 @@ class SteamUserMachineAuth extends SteamUserWeb {
 		this._machineAuthToken = machineToken;
 
 		this.emit('machineAuthToken', machineToken);
-		this.emit('sentry', Buffer.from(machineToken, 'utf8')); // legacy
 
 		// We should always have an account name available here since this is only possible when logging on using an
 		// account name and password.

--- a/components/09-logon.js
+++ b/components/09-logon.js
@@ -19,7 +19,26 @@ const SteamUserMachineAuth = require('./08-machineauth.js');
 const PROTOCOL_VERSION = 65580;
 const PRIVATE_IP_OBFUSCATION_MASK = 0xbaadf00d;
 
+/**
+ * @typedef LogOnDetails
+ * @property {boolean} [anonymous=false]
+ * @property {string} [refreshToken]
+ * @property {string} [accountName]
+ * @property {string} [password]
+ * @property {string} [machineAuthToken]
+ * @property {string} [webLogonToken]
+ * @property {string|SteamID} [steamID]
+ * @property {String} [authCode]
+ * @property {string} [twoFactorCode]
+ * @property {number} [logonID]
+ * @property {string} [machineName]
+ * @property {number} [clientOS]
+ */
+
 class SteamUserLogon extends SteamUserMachineAuth {
+	/**
+	 * @param {LogOnDetails} details
+	 */
 	logOn(details) {
 		// Delay the actual logon by one tick, so if users call logOn from the error event they won't get a crash because
 		// they appear to be already logged on (the steamID property is set to null only *after* the error event is emitted)

--- a/components/09-logon.js
+++ b/components/09-logon.js
@@ -335,6 +335,8 @@ class SteamUserLogon extends SteamUserMachineAuth {
 			});
 
 			session.on('authenticated', () => {
+				this.emit('refreshToken', session.refreshToken);
+
 				this._logOnDetails.access_token = session.refreshToken;
 				this._logOnDetails._newAuthAccountName = this._logOnDetails.account_name;
 				this._logOnDetails._steamid = session.steamID;

--- a/components/09-logon.js
+++ b/components/09-logon.js
@@ -330,7 +330,9 @@ class SteamUserLogon extends SteamUserMachineAuth {
 			let transport = new CMAuthTransport(this);
 			let session = new LoginSession(EAuthTokenPlatformType.SteamClient, {transport});
 
-			session.on('debug', (...args) => this.emit('debug', '[steam-session]', ...args));
+			session.on('debug', (...args) => {
+				this.emit('debug', '[steam-session] ' + args.map(arg => typeof arg == 'object' ? JSON.stringify(arg) : arg).join(' '));
+			});
 
 			session.on('authenticated', () => {
 				this._logOnDetails.access_token = session.refreshToken;

--- a/components/09-logon.js
+++ b/components/09-logon.js
@@ -56,7 +56,7 @@ class SteamUserLogon extends SteamUserMachineAuth {
 					login_key: details.loginKey,
 					auth_code: details.authCode,
 					two_factor_code: details.twoFactorCode,
-					should_remember_password: !!(details.rememberPassword || details.refreshToken),
+					should_remember_password: !!details.refreshToken,
 					obfuscated_private_ip: {v4: logonId || 0},
 					protocol_version: PROTOCOL_VERSION,
 					supports_rate_limit_response: !anonLogin,
@@ -551,7 +551,7 @@ class SteamUserLogon extends SteamUserMachineAuth {
 		);
 
 		if (!relogAvailable) {
-			throw new Error("To use relog(), you must specify rememberPassword=true when logging on and wait for loginKey to be emitted, or log on using a refresh token");
+			throw new Error('To use relog(), you must log on using a refresh token or using your account name and password');
 		}
 
 		this._relogging = true;

--- a/components/09-logon.js
+++ b/components/09-logon.js
@@ -88,7 +88,8 @@ class SteamUserLogon extends SteamUserMachineAuth {
 					ui_mode: undefined,
 					chat_mode: 2, // enable new chat
 					web_logon_nonce: details.webLogonToken && details.steamID ? details.webLogonToken : undefined,
-					_steamid: details.steamID
+					_steamid: details.steamID,
+					_machineAuthToken: details.machineAuthToken
 				};
 			}
 
@@ -234,11 +235,13 @@ class SteamUserLogon extends SteamUserMachineAuth {
 
 			// Machine auth token (only necessary if logging on with account name and password)
 			if (!anonLogin && !this._machineAuthToken && this._logOnDetails.account_name) {
-				let tokenContent = await this._readFile(this._getMachineAuthFilename());
+				let tokenContent = this._logOnDetails._machineAuthToken || this._readFile(this._getMachineAuthFilename());
 				if (tokenContent) {
 					this._machineAuthToken = tokenContent.toString('utf8').trim();
 				}
 			}
+
+			delete this._logOnDetails._machineAuthToken;
 
 			// Machine ID
 			if (!anonLogin && !this._logOnDetails.machine_id) {

--- a/components/09-logon.js
+++ b/components/09-logon.js
@@ -13,6 +13,8 @@ const EMachineIDType = require('../resources/EMachineIDType.js');
 const EMsg = require('../enums/EMsg.js');
 const EResult = require('../enums/EResult.js');
 
+const {EAuthSessionGuardType} = require('steam-session');
+
 const SteamUserBase = require('./00-base.js');
 const SteamUserMachineAuth = require('./08-machineauth.js');
 

--- a/components/classes/CMAuthTransport.js
+++ b/components/classes/CMAuthTransport.js
@@ -6,7 +6,7 @@ class CMAuthTransport {
 	_user;
 
 	/**
-	 * @param {SteamUserLogon} steamUser
+	 * @param {SteamUserMessages} steamUser
 	 */
 	constructor(steamUser) {
 		this._user = steamUser;

--- a/components/helpers.js
+++ b/components/helpers.js
@@ -254,8 +254,3 @@ exports.decodeJwt = function(jwt) {
 
 	return JSON.parse(Buffer.from(standardBase64, 'base64').toString('utf8'));
 }
-
-exports.newAuthCapable = function() {
-	let nodeVersion = process.versions.node.split('.');
-	return nodeVersion[0] > 12 || (nodeVersion[0] == 12 && nodeVersion[1] >= 22);
-};

--- a/index.js
+++ b/index.js
@@ -133,6 +133,8 @@ class SteamUser extends SteamUserTwoFactor {
 		this._useMessageQueue = false; // we only use the message queue while we're processing a multi message
 
 		delete this._machineAuthToken;
+		delete this._shouldAttemptRefreshTokenRenewal;
+		delete this._loginSession;
 	}
 
 	get packageName() {

--- a/index.js
+++ b/index.js
@@ -132,9 +132,7 @@ class SteamUser extends SteamUserTwoFactor {
 		this._incomingMessageQueue = [];
 		this._useMessageQueue = false; // we only use the message queue while we're processing a multi message
 
-		if (!this._machineAuthTokenSetByDeprecatedSetSentry) {
-			delete this._machineAuthToken;
-		}
+		delete this._machineAuthToken;
 	}
 
 	get packageName() {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	},
 	"dependencies": {
 		"@bbob/parser": "^2.2.0",
-		"@doctormckay/stdlib": "^2.7.0",
+		"@doctormckay/stdlib": "^2.7.1",
 		"@doctormckay/steam-crypto": "^1.2.0",
 		"adm-zip": "^0.5.10",
 		"binarykvparser": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"protobufjs": "^7.2.4",
 		"socks-proxy-agent": "^7.0.0",
 		"steam-appticket": "^1.0.1",
-		"steam-session": "^1.2.5",
+		"steam-session": "^1.3.0",
 		"steam-totp": "^2.0.1",
 		"steamid": "^2.0.0",
 		"websocket13": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"steam-session": "^1.3.0",
 		"steam-totp": "^2.0.1",
 		"steamid": "^2.0.0",
-		"websocket13": "^3.0.1"
+		"websocket13": "^4.0.0"
 	},
 	"devDependencies": {
 		"steamcommunity": "^3.39.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"protobufjs": "^7.2.4",
 		"socks-proxy-agent": "^7.0.0",
 		"steam-appticket": "^1.0.1",
-		"steam-session": "^1.3.0",
+		"steam-session": "^1.3.4",
 		"steam-totp": "^2.0.1",
 		"steamid": "^2.0.0",
 		"websocket13": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	},
 	"dependencies": {
 		"@bbob/parser": "^2.2.0",
-		"@doctormckay/stdlib": "^1.16.0",
+		"@doctormckay/stdlib": "^2.7.0",
 		"@doctormckay/steam-crypto": "^1.2.0",
 		"adm-zip": "^0.5.10",
 		"binarykvparser": "^2.2.0",
@@ -31,12 +31,12 @@
 		"file-manager": "^2.0.0",
 		"kvparser": "^1.0.1",
 		"lzma": "^2.3.2",
-		"protobufjs": "^6.11.3",
+		"protobufjs": "^7.2.4",
 		"socks-proxy-agent": "^7.0.0",
 		"steam-appticket": "^1.0.1",
 		"steam-session": "^1.2.5",
 		"steam-totp": "^2.0.1",
-		"steamid": "^1.1.0",
+		"steamid": "^2.0.0",
 		"websocket13": "^3.0.1"
 	},
 	"devDependencies": {
@@ -49,6 +49,6 @@
 		"generate-protos": "node scripts/generate-protos.js"
 	},
 	"engines": {
-		"node": ">=8.0.0"
+		"node": ">=14.0.0"
 	}
 }

--- a/resources/default_options.js
+++ b/resources/default_options.js
@@ -11,7 +11,7 @@ const EMachineIDType = require('./EMachineIDType.js');
  * @property {boolean} [picsCacheAll=false]
  * @property {number} [changelistUpdateInterval=60000]
  * @property {PackageFilter|PackageFilterFunction|null} [ownershipFilter=null]
- * @property {object} [additionalHeaders={}}
+ * @property {object} [additionalHeaders={}]
  * @property {string|null} [localAddress=null]
  * @property {number|null} [localPort=null]
  * @property {string|null} [httpProxy=null]
@@ -20,6 +20,7 @@ const EMachineIDType = require('./EMachineIDType.js');
  * @property {string} [language='english']
  * @property {boolean} [webCompatibilityMode=false]
  * @property {boolean} [saveAppTickets=true]
+ * @property {boolean} [renewRefreshTokens=false]
  */
 
 module.exports = {
@@ -37,5 +38,6 @@ module.exports = {
 	protocol: EConnectionProtocol.Auto,
 	language: 'english',
 	webCompatibilityMode: false,
-	saveAppTickets: true
+	saveAppTickets: true,
+	renewRefreshTokens: false
 };


### PR DESCRIPTION
# [Migration Guide](https://github.com/DoctorMcKay/node-steam-user/wiki/v4-%E2%86%92-v5-migration-guide)

# Breaking

- Now requires Node.js v14 or later (up from v8)
- Removed deprecated methods
    - `setSentry()`
- Removed deprecated events
    - `sentry`
- Removed deprecated login key functionality
    - Removed logOn properties: `loginKey` and `rememberPassword`
- Removed legacy authentication

# Other Changes

- Added `refreshToken` event
- Added `renewRefreshTokens` option

# To Do

- [x] Remove `setSentry()`
- [x] Remove `sentry` event
- [x] Remove login key functionality
- [x] Remove legacy auth
- [x] Add jsdoc to logOn
- [x] Probably add some event to access refresh tokens
- [x] Refresh token renewal