### PR TITLE
Add support for all options of Player.GetOwnedGames#1

### DIFF
--- a/components/friends.js
+++ b/components/friends.js
@@ -844,10 +844,11 @@ class SteamUserFriends extends SteamUserFamilySharing {
 			steamID = Helpers.steamID(steamID);
 			this._sendUnified('Player.GetOwnedGames#1', {
 				steamid: steamID.toString(),
-				include_appinfo: true,
+				include_appinfo: options.includeAppInfo ?? true,
 				include_played_free_games: options.includePlayedFreeGames || false,
 				appids_filter: options.filterAppids || undefined,
-				include_free_sub: options.includeFreeSub || false
+				include_free_sub: options.includeFreeSub || false,
+				skip_unvetted_apps: options.skipUnvettedApps ?? true
 			}, (body, hdr) => {
 				let err = Helpers.eresultError(hdr.proto);
 				if (err) {


### PR DESCRIPTION
You can now modify all options/flags that are available for the `Player.GetOwnedGames#1` request.

* `include_appinfo` is still true by default, but you can turn it off if you don't wish to receive apps' name and icon url
* unvetted apps are skipped by default on Steam side. Sending `skip_unvetted_apps=false` will include the otherwise skipped apps

After this change, all the previous usages of the `SteamUserFriends.getUserOwnedApps` method continues to work exactly the same way, but now you can pass in 2 extra options that you previously couldn't.