### PR TITLE
Fix of the SteamUser.getUserOwnedApps return type

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,6 +2,5 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/../steam-user wiki" vcs="Git" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -1322,8 +1322,8 @@ Gets your own Steam Level, and the level you have on a badge for a particular ga
 - `callback` - Called when the request completes.
     - `err` - An `Error` object on failure or `null` on success.
     - `response` - The response object
-        - `game_count` - A number indicating how many total apps this user owns
-        - `games` - An array of objects:
+        - `app_count` - A number indicating how many total apps this user owns
+        - `apps` - An array of objects:
             - `appid` - The ID of the app
             - `name` - The name of the app
             - `playtime_2weeks` - How many minutes this user has played in the past 2 weeks (may be `null`)


### PR DESCRIPTION
Hi.

I had problems recently with the SteamUser.getUserOwnedApps() method.

The [TypeScript-Types](https://www.npmjs.com/package/@types/steam-user) for this package and the [README.md](https://github.com/DoctorMcKay/node-steam-user/blob/master/README.md#getuserownedappssteamid-options-callback) inside does not have the correct return type for this method.

The existing issue: https://github.com/DoctorMcKay/node-steam-user/issues/471