### PR TITLE
fix: fixed ws disconnected state on connection end

### DIFF
--- a/components/connection_protocols/websocket.js
+++ b/components/connection_protocols/websocket.js
@@ -99,6 +99,11 @@ class WebSocketConnection extends BaseConnection {
 				this.stream.removeAllListeners();
 				this.stream.on('error', () => {
 				});
+
+				this.stream.disconnect();
+				this._disconnected = true;
+
+				return;
 			}
 
 			this.stream.disconnect();


### PR DESCRIPTION
Since events are ignored
https://github.com/DoctorMcKay/node-steam-user/blob/686d773f88df373ed0e7be845a37c46dd081d9b1/components/connection_protocols/websocket.js#L98-L102

We can't catch `disconnected` event later, so disconnected state is not properly updated.