### PR TITLE
fix: fixed inconsistent machine id between logins

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,8 +568,9 @@ There are five ways to log onto Steam:
       default to logging on anonymously. This is still current behavior, but logging on in this manner is now deprecated.
       If you now call `logOn()` without providing a `refreshToken` or `accountName` and without specifying `anonymous: true`,
       then steam-user will raise a warning and then log on anonymously.
-- Individually using a refresh token **(recommended)**
+- Individually using a refresh token and account name **(recommended)**
 	- These properties are required:
+        - `accountName`
         - `refreshToken`
     - These properties are optional:
         - `steamID` - If provided, steam-user will check to make sure that the provided `refreshToken` matches this SteamID. If SteamIDs don't match, the app will crash.
@@ -577,7 +578,6 @@ There are five ways to log onto Steam:
         - `machineName` - Defaults to empty string if not specified.
         - `clientOS` - Defaults to an auto-detected value if not specified.
     - These properties must not be provided:
-        - `accountName`
         - `password`
         - `machineAuthToken`
         - `webLogonToken`

--- a/components/09-logon.js
+++ b/components/09-logon.js
@@ -557,8 +557,6 @@ class SteamUserLogon extends SteamUserMachineAuth {
 		if (
 			(
 				!this._logOnDetails.account_name
-				&& !this._logOnDetails.password
-				&& !this._logOnDetails.access_token
 				&& !this._logOnDetails._steamid
 			)
 			|| this.options.machineIdType == EMachineIDType.None

--- a/components/09-logon.js
+++ b/components/09-logon.js
@@ -78,7 +78,7 @@ class SteamUserLogon extends SteamUserMachineAuth {
 					}
 				}
 
-				let anonLogin = !details.accountName && !details.refreshToken;
+				let anonLogin = !details.accountName && !details.password && !details.refreshToken;
 
 				this._logOnDetails = {
 					account_name: details.accountName,

--- a/components/09-logon.js
+++ b/components/09-logon.js
@@ -122,7 +122,6 @@ class SteamUserLogon extends SteamUserMachineAuth {
 			if (details.refreshToken) {
 				// If logging in with a refresh token, we need to make sure that no conflicting properties are set
 				let disallowedProps = [
-					'account_name',
 					'password',
 					'auth_code',
 					'two_factor_code'
@@ -171,7 +170,7 @@ class SteamUserLogon extends SteamUserMachineAuth {
 				}
 			}
 
-			let anonLogin = !this._logOnDetails.account_name && !this._logOnDetails.access_token;
+			let anonLogin = !this._logOnDetails.account_name && !this._logOnDetails.password && !this._logOnDetails.access_token;
 			let explicitlyRequestedAnonLogin = details !== true && details.anonymous;
 			if (explicitlyRequestedAnonLogin && !anonLogin) {
 				this._warn('Anonymous logon was requested but account details were specified; logging into specified individual user account');
@@ -209,8 +208,8 @@ class SteamUserLogon extends SteamUserMachineAuth {
 				}
 			});
 
-			// Machine auth token (only necessary if logging on with account name and password)
-			if (!anonLogin && !this._machineAuthToken && this._logOnDetails.account_name) {
+			// Machine auth token (only necessary if logging on with account name and password && email-based Steam Guard)
+			if (!anonLogin && !this._machineAuthToken && this._logOnDetails.account_name && this._logOnDetails.password) {
 				let tokenContent = this._logOnDetails._machineAuthToken || await this._readFile(this._getMachineAuthFilename());
 				if (tokenContent) {
 					this._machineAuthToken = tokenContent.toString('utf8').trim();
@@ -558,6 +557,8 @@ class SteamUserLogon extends SteamUserMachineAuth {
 		if (
 			(
 				!this._logOnDetails.account_name
+				&& !this._logOnDetails.password
+				&& !this._logOnDetails.access_token
 				&& !this._logOnDetails._steamid
 			)
 			|| this.options.machineIdType == EMachineIDType.None


### PR DESCRIPTION
ref: https://github.com/DoctorMcKay/node-steam-user/issues/502

looks like just allowance to use account_name will work fine

also, added some additional checks to ensure that logins is not anonymous