### PR TITLE
fix: allow to pass null and undefined as httpProxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,7 +223,7 @@ class SteamUser extends SteamUserTwoFactor {
 				break;
 
 			case 'httpProxy':
-				if (typeof this.options.httpProxy == 'string' && !this.options.httpProxy.includes('://')) {
+				if (this.options.httpProxy && typeof this.options.httpProxy == 'string' && !this.options.httpProxy.includes('://')) {
 					this.options.httpProxy = 'http://' + this.options.httpProxy;
 				}
 				break;


### PR DESCRIPTION
Very minor (but a bit annoying) thing.

```
    this.client = new SteamUser({
           httpProxy: config.proxyConfiguration
        });
```

fails because it renders `http://` as a url to proxy

whoever maintains `@types/steam-user` (know it's not you), says nulls should work, but they also don't.
That patch should do the trick