### PR TITLE
feat: add `webLogOn` backoff reset to reconnect timers

### DIFF
--- a/components/02-connection.js
+++ b/components/02-connection.js
@@ -70,6 +70,8 @@ class SteamUserConnection extends SteamUserEnums {
 
 	_cancelReconnectTimers(dontClearBackoffTime) {
 		this._resetExponentialBackoff('logOn', dontClearBackoffTime);
+		this._resetExponentialBackoff('webLogOn', dontClearBackoffTime);
+
 		clearTimeout(this._reconnectForCloseDuringAuthTimeout);
 	}
 


### PR DESCRIPTION
fix for: https://github.com/DoctorMcKay/node-steam-user/issues/515